### PR TITLE
MS-1442 Update Medaille Trust domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports =
 'nccgroup.com',
 'hscni.net',
 'migranthelpuk.org',
-'medailletrust.org.uk',
+'medaille-trust.org.uk',
 'salvationarmy.org.uk',
 'barnardos.org.uk',
 'nspcc.org.uk',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-email-domains",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Exports a list of email-domains that are recognised for the modern-slavery service",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This commit amends the whitelist by removing medailletrust.org.uk, which
is not a domain that exists, and adding medaille-trust.org.uk, which is
the correct domain for The Medaille Trust Limited.