### PR TITLE
SD-96 Temporarily add nccgroup.com

### DIFF
--- a/email-domain-list.json
+++ b/email-domain-list.json
@@ -23,6 +23,7 @@
     "met.police.uk",
     "midulstercouncil.org",
     "migranthelpuk.org",
+    "nccgroup.com",
     "newpathways.org.uk",
     "nmandd.org",
     "nspcc.org.uk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-email-domains",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Exports a list of email-domains that are recognised for the modern-slavery service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What?
Modern slavery has an email domain whitelist.  There are reasons.  Add nccgroup to the email domain.

## Why?
Because they are doing an IT health check

## Note
This group should be deleted later