### PR TITLE
SD-96 adding more NCC email domains for ITHC

### DIFF
--- a/email-domain-list.json
+++ b/email-domain-list.json
@@ -24,6 +24,8 @@
     "midulstercouncil.org",
     "migranthelpuk.org",
     "nccgroup.com",
+    "nccgroup.trust",
+    "ngssecure.com",
     "newpathways.org.uk",
     "nmandd.org",
     "nspcc.org.uk",


### PR DESCRIPTION
## What

Adding more nccgroup email domains 

## Why

For the ITHC that is taking place today and the next few days