### PR TITLE
Remove refugee council domain

### DIFF
--- a/email-domain-list.json
+++ b/email-domain-list.json
@@ -31,7 +31,6 @@
     "psni.pnn.police.uk",
     "psni.police.uk",
     "rbkc.gov.uk",
-    "refugeecouncil.org.uk",
     "salvationarmy.org.uk",
     "salvationarmy.org.uk.cjsm.net",
     "sandwellchildrenstrust.org",


### PR DESCRIPTION
Remove refugeee council domain as they have withdrawn from their role as a First Responder organisation.