### PR TITLE
NRM-133: allow email domains with capital letters

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,4 @@ const domainFunctions = require('./domain-functions.js')
 
 module.exports = emailDomainList
 
-module.exports.isValidDomain = (domain) => (domainFunctions.isOnDomainList(domain) || domainFunctions.isOnExtensionsList(domain))
+module.exports.isValidDomain = (domain) => (domainFunctions.isOnDomainList(domain.toLowerCase()) || domainFunctions.isOnExtensionsList(domain.toLowerCase()))


### PR DESCRIPTION
## What?
Allow email domains with capital letters
## Why?
Users are not able to access the form because they were entering capital letters in the domain of their email address.
## How?
Added a `toLowerCase()` method to transform input to lowercase before matching against domain list
